### PR TITLE
Added '/' to destination directories for ADD rules

### DIFF
--- a/node_docker/Dockerfile
+++ b/node_docker/Dockerfile
@@ -21,7 +21,7 @@ ADD ./package.json .
 
 # RUN command runs the command in command line
 RUN mkdir ./src
-ADD ./src/* ./src
+ADD ./src/* ./src/
 
 # EXPOSE opens up the port to communication outside the container.
 # WE ASSUME THAT YOUR SERVER WILL RUN ON THIS PORT. 

--- a/python_docker/Dockerfile
+++ b/python_docker/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR client
 # ADD command adds the file or folder to the destination. 
 # Since the working directory is `./client`, it copies the file inside `./client`.
 RUN mkdir ./src
-ADD ./src/* ./src
+ADD ./src/* ./src/
 ADD ./requirements.txt .
 
 # RUN commands are run when the docker image is built. 


### PR DESCRIPTION
Bug fix to this error: "When using ADD with more than one source file, the destination must be a directory and end with a /. "

Fixes #6 that I opened as it seems creating an issue beforehand was required.

## Checklist 

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation (if necessary)
- [x] I have performed adequate tests that prove my fix is effective or that my feature works

## Proposed Changes

- Simple fix to the Dockerfile really. Add '/' to the end of the command in question.
